### PR TITLE
add p value to return list

### DIFF
--- a/lincomestadd.ado
+++ b/lincomestadd.ado
@@ -41,5 +41,6 @@ estadd local `statname't "`tstring'"
 estadd scalar `statname'b_num = `bnum'
 estadd scalar `statname'se_num = `senum'
 estadd scalar `statname't_num = `tnum'
+estadd scalar `statname'pvalue_num = `pvalue'
 
 end

--- a/lincomestadd.sthlp
+++ b/lincomestadd.sthlp
@@ -42,7 +42,7 @@ It saves into e() the formatted strings
 where the strings are formatted according to {format(%fmt)}}, with default %04.3f. It also includes significance stars on e({it:prefix}b) unless the option {opt nostars} is specified. Parentheses are placed around the standard error.
 
 {pstd}
-It also saves all of the non-formatted results as numeric values in e({it:prefix}stat_num).
+It also saves all of the non-formatted results as numeric values in e({it:prefix}stat_num). In addition, it also saves the {it:p}-value as numeric value in e({it:prefix}pvalue_num).
 
 {pstd}
 The formatted strings are particularly useful when making tables with e()-results.


### PR DESCRIPTION
hi Ben,

thank you for this package, this proves to be extremely useful.

I amended the code with a slight modification so that it returns the p-value of `lincom` in addition to `b`, `se`, `df`, and `t`.
It can come as handy when it comes to producing output using `estout` or `esttab`.

As opposed to the other outputs, the p-value is saved only as scalar and not as formatted string in this version.

All the best,
Marton